### PR TITLE
feat: add bilinear LCD scaling

### DIFF
--- a/PicoPad/EMU/GBC/SCALING_FILTER.md
+++ b/PicoPad/EMU/GBC/SCALING_FILTER.md
@@ -12,5 +12,6 @@ using bilinear interpolation with lookup tables:
 
 Fractions (0–2 for X, 0–4 for Y) are packed together with source indices
 in `lut_x` and `lut_y`. During rendering the precomputed weights are
-combined using integer arithmetic (adds, multiplies and shifts) to
-minimize CPU load on the RP2040.
+combined using integer arithmetic that replaces slow divisions with
+`(x*171)>>9` and `(x*205)>>10` sequences, keeping the RP2040 free from
+64‑bit operations.

--- a/PicoPad/EMU/GBC/SCALING_FILTER.md
+++ b/PicoPad/EMU/GBC/SCALING_FILTER.md
@@ -1,0 +1,16 @@
+# LCD Scaling Filter
+
+The emulator scales the Game Boy's 160×144 image to the 240×240 display
+using bilinear interpolation with lookup tables:
+
+- **Horizontal**: three phases per pair of pixels. The fraction values
+  repeat in the pattern `0,2,1` representing weights of 0, 2/3 and
+  1/3 for the second source pixel.
+- **Vertical**: five phases between lines. Fractions follow the pattern
+  `0,3,1,4,2`, corresponding to weights of 0, 3/5, 1/5, 4/5 and 2/5 for
+  the lower line.
+
+Fractions (0–2 for X, 0–4 for Y) are packed together with source indices
+in `lut_x` and `lut_y`. During rendering the precomputed weights are
+combined using integer arithmetic (adds, multiplies and shifts) to
+minimize CPU load on the RP2040.


### PR DESCRIPTION
## Summary
- encode source index and interpolation fraction in x/y lookup tables
- blend horizontal pixels and adjacent lines using integer bilinear filter
- document scaling weights for the new filter

## Testing
- `bash ../../../_c1.sh` *(fails: arm-none-eabi-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2b3d8b508323b4a7bc1f69f4b5b8