### PR TITLE
Adjust LCD offset for portrait modes

### DIFF
--- a/PicoPad/EMU/GBC/config.h
+++ b/PicoPad/EMU/GBC/config.h
@@ -111,6 +111,14 @@
 //#define USE_REAL8192		1		// 1 = use real8192 numbers
 //#define USE_REAL12288		1		// 1 = use real12288 numbers
 
-#include CONFIG_DEF_H				// default configuration
+#include CONFIG_DEF_H                           // default configuration
+
+#if (DISP_ROT == 0) || (DISP_ROT == 2)
+#define DISP_OFFSET_X 0
+#define DISP_OFFSET_Y 80
+#else
+#define DISP_OFFSET_X 80
+#define DISP_OFFSET_Y 0
+#endif
 
 #endif // _CONFIG_H

--- a/PicoPad/EMU/NES/config.h
+++ b/PicoPad/EMU/NES/config.h
@@ -143,6 +143,14 @@
 //#define USE_REAL8192		1		// 1 = use real8192 numbers
 //#define USE_REAL12288		1		// 1 = use real12288 numbers
 
-#include CONFIG_DEF_H				// default configuration
+#include CONFIG_DEF_H                           // default configuration
+
+#if (DISP_ROT == 0) || (DISP_ROT == 2)
+#define DISP_OFFSET_X 0
+#define DISP_OFFSET_Y 80
+#else
+#define DISP_OFFSET_X 80
+#define DISP_OFFSET_Y 0
+#endif
 
 #endif // _CONFIG_H

--- a/_loader/LOADER/LOADER/config.h
+++ b/_loader/LOADER/LOADER/config.h
@@ -149,5 +149,12 @@
 #define FONTH		16		// height of system font
 
 #include "../../../config_def.h"	// default configuration
+#if (DISP_ROT == 0) || (DISP_ROT == 2)
+#define DISP_OFFSET_X 0
+#define DISP_OFFSET_Y 80
+#else
+#define DISP_OFFSET_X 80
+#define DISP_OFFSET_Y 0
+#endif
 
 #endif // _CONFIG_H


### PR DESCRIPTION
## Summary
- compute ST7789 framebuffer offsets for portrait rotations
- apply offset logic to GBC, NES, and loader configurations

## Testing
- `bash ../../../_c1.sh picopad10` (fails: No rule to make target '../../../_loader/loader_picopad10.S')

------
https://chatgpt.com/codex/tasks/task_e_68bcae5d0388832381cc01c892528cba